### PR TITLE
fix: 인증용 후기글 이미 존재할 경우 예외처리

### DIFF
--- a/whew-are-you-BE/bingo/views.py
+++ b/whew-are-you-BE/bingo/views.py
@@ -334,10 +334,12 @@ class BingoReviewAPIView(APIView):
             for todo in todos: 
                 if not todo.is_completed:
                     return Response({"error": "투두 항목이 모두 완료되어야 후기글 작성이 가능합니다.", "short_code": "todo_remaining"}, status=status.HTTP_400_BAD_REQUEST)
-
-            serializer.save(user=request.user)
+            #여기서 이미 인증용 후기글이 존재하면 500 Integrity Err말고 예외처리를 해주자
+            if bingo_space.review:
+                return Response({'error': "기작성된 인증용 후기글이 존재합니다."}, status=status.HTTP_400_BAD_REQUEST)
+            else:
+                serializer.save(user=request.user)
             return Response(serializer.data, status=status.HTTP_201_CREATED)
-        print(serializer.errors)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
     
 class BingoRecsAPIView(APIView):


### PR DESCRIPTION
## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지
- 사실 별거 아닌데, 인증용 후기글 한 bingospace에 중복작성할 때 500 에러 뜨는 거 싫어서 그냥 예외처리 추가해준거임.

  <br/>

## 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 과제

- 내일 할 일

  <br/>

## ➕ 이슈 링크
