### PR TITLE
feat: bingo/recs/saved/에서 후기글의 ProvidedBingoItem id값 추가

### DIFF
--- a/whew-are-you-BE/review_information/serializers.py
+++ b/whew-are-you-BE/review_information/serializers.py
@@ -212,12 +212,13 @@ class ReviewGETSerializer(serializers.ModelSerializer):
     comments_count = serializers.IntegerField(read_only=True)
     is_liked_by_user = serializers.SerializerMethodField()
     todo = serializers.SerializerMethodField(read_only=True) #인증용 후기글이 아니면 null, 인증용 후기글인데 비어있으면 []
+    provided_bingo_item = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = Review
         fields = ['id', 'title', 'large_category', 'start_date', 'end_date', 'content', 'duty', 'employment_form', 'area', 
                   'host', 'app_fee', 'date', 'app_due', 'field', 'procedure', 'images', 'detailplans', 'likes', 'large_category_display',
-                  'author_id', 'author', 'created_at', 'profile', 'likes_count', 'comments_count', 'is_liked_by_user', 'storage', 'todo']
+                  'author_id', 'author', 'created_at', 'profile', 'likes_count', 'comments_count', 'is_liked_by_user', 'storage', 'todo', 'provided_bingo_item']
         
     def get_large_category_display(self, obj):
         return obj.get_large_category_display()
@@ -235,6 +236,12 @@ class ReviewGETSerializer(serializers.ModelSerializer):
             return todo_serialized.data
         else:
             return None #인증용 후기글이 아니면 null, 인증용 후기글인데 비어있으면 []
+        
+    def get_provided_bingo_item(self, obj):
+        if obj.bingo_space and obj.bingo_space.recommend_content:
+            return obj.bingo_space.recommend_content.id
+        else:
+            return None
 
     def to_representation(self, instance):
         rep = super().to_representation(instance)


### PR DESCRIPTION
## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지

saved_notices는 ProvidedBingoItem과 1:1 대응되므로 provided_bingo_item 필드가 있었지만,
saved_reviews는 늘 ProvidedBingoItem과 1:1 대응되지 않으므로 해당 필드가 없었다.

이번 커밋에서 GET /bingo/recs/saved/ 시 후기글을 통해 원본 ProvidedBingoItem(존재하는 경우에 한해)의 id를 provided_bingo_item 필드를 통해 반환한다.
(존재하지 않을 경우 null)

  <br/>

## 이미지 첨부

<img src="파일주소" width="50%" height="50%"/>

<br/>

## 🔧 앞으로의 과제

- 내일 할 일

  <br/>

## ➕ 이슈 링크
